### PR TITLE
CommandLineInterface can handle invalid login attempts and n-number of retries.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -54,9 +54,9 @@ artifacts {
 	archives javadocJar
 }
 
-signing {
-    sign configurations.archives
-}
+//signing {
+//    sign configurations.archives
+//}
 
 def getMaven = { ->
         def stdout = new ByteArrayOutputStream()
@@ -71,6 +71,7 @@ project.ext.maven = getMaven()
 
 uploadArchives {
     repositories {
+	mavenLocal()
         mavenDeployer {
             beforeDeployment { MavenDeployment deployment -> signing.signPom(deployment) }
 

--- a/build.gradle
+++ b/build.gradle
@@ -54,9 +54,9 @@ artifacts {
 	archives javadocJar
 }
 
-//signing {
-//    sign configurations.archives
-//}
+signing {
+    sign configurations.archives
+}
 
 def getMaven = { ->
         def stdout = new ByteArrayOutputStream()
@@ -71,7 +71,6 @@ project.ext.maven = getMaven()
 
 uploadArchives {
     repositories {
-	mavenLocal()
         mavenDeployer {
             beforeDeployment { MavenDeployment deployment -> signing.signPom(deployment) }
 

--- a/src/main/java/org/cinchapi/concourse/cli/CommandLineInterface.java
+++ b/src/main/java/org/cinchapi/concourse/cli/CommandLineInterface.java
@@ -45,33 +45,35 @@ import com.google.common.base.Strings;
  * @author jnelson
  */
 public abstract class CommandLineInterface {
-   
-	/**
+
+    /**
      * Internal {@link Concourse} instance for interface.
      */
-	private Concourse concourse; 
-	
-	/**
-	 * Access to  {@link #concourse} instance.
-	 * @return
-	 */
-	public final Concourse getConcourse(){
-		return concourse;
-	}
-	
-	/**
-	 * The number of login attempts remaining before system will exit.
-	 */
-	private int loginAttemptsRemaining;
-	
-	/**
-	 * Setter for {@link #loginAttemptsRemaining}.
-	 * @param loginAttemptsRemaining
-	 */
-	public final void setLoginAttemptsRemaining (int loginAttemptsRemaining){
-		this.loginAttemptsRemaining = loginAttemptsRemaining;
-	}
-	
+    private Concourse concourse;
+
+    /**
+     * Access to {@link #concourse} instance.
+     * 
+     * @return
+     */
+    public final Concourse getConcourse() {
+        return concourse;
+    }
+
+    /**
+     * The number of login attempts remaining before system will exit.
+     */
+    private int loginAttemptsRemaining;
+
+    /**
+     * Setter for {@link #loginAttemptsRemaining}.
+     * 
+     * @param loginAttemptsRemaining
+     */
+    public final void setLoginAttemptsRemaining(int loginAttemptsRemaining) {
+        this.loginAttemptsRemaining = loginAttemptsRemaining;
+    }
+
     /**
      * The CLI options.
      */
@@ -143,7 +145,7 @@ public abstract class CommandLineInterface {
                 options.environment = prefs.getEnvironment();
             }
             else if(Strings.isNullOrEmpty(options.password)) {
-            	setPasswordFromConsole();
+                setPasswordFromConsole();
             }
         }
         catch (ParameterException e) {
@@ -186,56 +188,64 @@ public abstract class CommandLineInterface {
      * </p>
      */
     protected abstract void doTask();
-    
+
     /**
-     * Reads a password from {@link #console} to set for {@link #options} password.
+     * Reads a password from {@link #console} to set for {@link #options}
+     * password.
+     * 
      * @throws IOException
      */
-    private void setPasswordFromConsole () {
+    private void setPasswordFromConsole() {
         try {
-			options.password = console.readLine("Password ["
-			        + options.username + "]: ", '*');
-		} catch (IOException e) {
-            die(e.getMessage());		
-		}
+            options.password = console.readLine("Password [" + options.username
+                    + "]: ", '*');
+        }
+        catch (IOException e) {
+            die(e.getMessage());
+        }
     }
-    
+
     /**
      * Connect to {@value #concourse} with options,
      * call upon {@link #handleInvalidLogin()} to handle a retry.
-     * @throws IOException 
+     * 
+     * @throws IOException
      */
-	protected void connectToConcourse() {
-        try{
-        	concourse = (Concourse.connect(options.host, options.port, options.username, options.password));
+    protected void connectToConcourse() {
+        try {
+            concourse = (Concourse.connect(options.host, options.port,
+                    options.username, options.password));
         }
-        catch (RuntimeException e){
-        	if (e.getCause() instanceof TApplicationException){
-        		handleInvalidLogin();
-        	}
-        }	
-	}
-	
-	/**
-	 * Handle an invalid login: 
-	 * 		1) decrementing {@link #loginAttemptsRemaining}.
-	 * 		2) prompt for a new password.
-	 * 		3) re-attempt {@link #connectToConcourse()}.
-	 * 
-	 * If {@link #loginAttemptsRemaining} has expired, then flag {@link #isLoginFailed}.
-	 * 
-	 * @throws IOException
-	 */
-	private void handleInvalidLogin() {
-		loginAttemptsRemaining -= 1;
-		if (loginAttemptsRemaining > 0){
-    		System.err.println ("Error processing login.  Please check username/password combination and try again.");
-    		setPasswordFromConsole();
-    		connectToConcourse();
-		}
-		else {
-			isLoginFailed = true;
-    		System.err.println ("Error processing login.  Please check username/password combination and try again.");
-		}		
-	}
+        catch (RuntimeException e) {
+            if(e.getCause() instanceof TApplicationException) {
+                handleInvalidLogin();
+            }
+        }
+    }
+
+    /**
+     * Handle an invalid login:
+     * 1) decrementing {@link #loginAttemptsRemaining}.
+     * 2) prompt for a new password.
+     * 3) re-attempt {@link #connectToConcourse()}.
+     * 
+     * If {@link #loginAttemptsRemaining} has expired, then flag
+     * {@link #isLoginFailed}.
+     * 
+     * @throws IOException
+     */
+    private void handleInvalidLogin() {
+        loginAttemptsRemaining -= 1;
+        if(loginAttemptsRemaining > 0) {
+            System.err
+                    .println("Error processing login.  Please check username/password combination and try again.");
+            setPasswordFromConsole();
+            connectToConcourse();
+        }
+        else {
+            isLoginFailed = true;
+            System.err
+                    .println("Error processing login.  Please check username/password combination and try again.");
+        }
+    }
 }

--- a/src/main/java/org/cinchapi/concourse/cli/Options.java
+++ b/src/main/java/org/cinchapi/concourse/cli/Options.java
@@ -60,7 +60,7 @@ public class Options {
             prefsHandler = ConcourseClientPreferences.load(file);
         }
     }
-    
+
     @Parameter(names = { "--help" }, help = true, hidden = true)
     public boolean help;
 

--- a/src/test/org/cinchapi/concourse/cli/CommandLineInterfaceTest.java
+++ b/src/test/org/cinchapi/concourse/cli/CommandLineInterfaceTest.java
@@ -4,53 +4,67 @@ import org.junit.Assert;
 import org.cinchapi.concourse.test.ClientServerTest;
 import org.junit.Test;
 
-public class CommandLineInterfaceTest extends ClientServerTest  {
+public class CommandLineInterfaceTest extends ClientServerTest {
 
-	/**
-	 * Tests passing an invalid password to a test CLI.
-	 */
-	@Test
-	public void testInvalidPassword(){
-		// Test that passing a valid password results in a Concourse instance.
-		String[] validArgs = {"--password", "admin", "-p", String.valueOf(server.getClientPort())};
-		TestCommandLineInterface validTestCLI = new TestCommandLineInterface (new Options(), validArgs);
-		Assert.assertNotEquals("CLI with valid login, Concourse instance not null", validTestCLI.getConcourse(), null); 
+    /**
+     * Tests passing an invalid password to a test CLI.
+     */
+    @Test
+    public void testInvalidPassword() {
+        // Test that passing a valid password results in a Concourse instance.
+        String[] validArgs = { "--password", "admin", "-p",
+                String.valueOf(server.getClientPort()) };
+        TestCommandLineInterface validTestCLI = new TestCommandLineInterface(
+                new Options(), validArgs);
+        Assert.assertNotEquals(
+                "CLI with valid login, Concourse instance not null",
+                validTestCLI.getConcourse(), null);
 
-		// Test that passing an invalid password results in a null Concourse instance.
-		String[] invalidArgs = {"--password", "invalid", "-p", String.valueOf(server.getClientPort())};
-		TestCommandLineInterface invalidTestCLI = new TestCommandLineInterface (new Options(), invalidArgs);
-		Assert.assertEquals ("CLI with invalid login, Concourse instance null", invalidTestCLI.getConcourse(), null);
-		Assert.assertEquals ("Invalid login failed", true, invalidTestCLI.isLoginFailed);
-		
-		// Test that passing an invalid port results in a null Concourse instance.
-		String[] invalidPortArgs = {"--password", "admin", "-p", "0"};
-		TestCommandLineInterface invalidPortTestCLI = new TestCommandLineInterface (new Options(), invalidPortArgs);
-		Assert.assertEquals ("CLI with invalid port, Concourse instance null", invalidPortTestCLI.getConcourse(), null);
-	}
-	
-	/**
-	 * Test {@link CommandLineInterface} for testing purposes, simply exists to take
-	 * command-line options and to attempt a Concourse connection.
-	 * @author hmitchell
-	 *
-	 */
-	private class TestCommandLineInterface extends CommandLineInterface{
-				
-		protected TestCommandLineInterface(Options options, String[] args) {
-			super(options, args);
-			setLoginAttemptsRemaining (0);
-			connectToConcourse();
-		}
+        // Test that passing an invalid password results in a null Concourse
+        // instance.
+        String[] invalidArgs = { "--password", "invalid", "-p",
+                String.valueOf(server.getClientPort()) };
+        TestCommandLineInterface invalidTestCLI = new TestCommandLineInterface(
+                new Options(), invalidArgs);
+        Assert.assertEquals("CLI with invalid login, Concourse instance null",
+                invalidTestCLI.getConcourse(), null);
+        Assert.assertEquals("Invalid login failed", true,
+                invalidTestCLI.isLoginFailed);
 
-		@Override
-		protected void doTask() {
-			// does nothing.
-		}
-		
-	}
+        // Test that passing an invalid port results in a null Concourse
+        // instance.
+        String[] invalidPortArgs = { "--password", "admin", "-p", "0" };
+        TestCommandLineInterface invalidPortTestCLI = new TestCommandLineInterface(
+                new Options(), invalidPortArgs);
+        Assert.assertEquals("CLI with invalid port, Concourse instance null",
+                invalidPortTestCLI.getConcourse(), null);
+    }
 
-	@Override
-	protected String getServerVersion() {
+    /**
+     * Test {@link CommandLineInterface} for testing purposes, simply exists to
+     * take
+     * command-line options and to attempt a Concourse connection.
+     * 
+     * @author hmitchell
+     *
+     */
+    private class TestCommandLineInterface extends CommandLineInterface {
+
+        protected TestCommandLineInterface(Options options, String[] args) {
+            super(options, args);
+            setLoginAttemptsRemaining(0);
+            connectToConcourse();
+        }
+
+        @Override
+        protected void doTask() {
+            // does nothing.
+        }
+
+    }
+
+    @Override
+    protected String getServerVersion() {
         return "0.3.4";
-	}
+    }
 }

--- a/src/test/org/cinchapi/concourse/cli/CommandLineInterfaceTest.java
+++ b/src/test/org/cinchapi/concourse/cli/CommandLineInterfaceTest.java
@@ -1,0 +1,56 @@
+package org.cinchapi.concourse.cli;
+
+import org.junit.Assert;
+import org.cinchapi.concourse.test.ClientServerTest;
+import org.junit.Test;
+
+public class CommandLineInterfaceTest extends ClientServerTest  {
+
+	/**
+	 * Tests passing an invalid password to a test CLI.
+	 */
+	@Test
+	public void testInvalidPassword(){
+		// Test that passing a valid password results in a Concourse instance.
+		String[] validArgs = {"--password", "admin", "-p", String.valueOf(server.getClientPort())};
+		TestCommandLineInterface validTestCLI = new TestCommandLineInterface (new Options(), validArgs);
+		Assert.assertNotEquals("CLI with valid login, Concourse instance not null", validTestCLI.getConcourse(), null); 
+
+		// Test that passing an invalid password results in a null Concourse instance.
+		String[] invalidArgs = {"--password", "invalid", "-p", String.valueOf(server.getClientPort())};
+		TestCommandLineInterface invalidTestCLI = new TestCommandLineInterface (new Options(), invalidArgs);
+		Assert.assertEquals ("CLI with invalid login, Concourse instance null", invalidTestCLI.getConcourse(), null);
+		Assert.assertEquals ("Invalid login failed", true, invalidTestCLI.isLoginFailed);
+		
+		// Test that passing an invalid port results in a null Concourse instance.
+		String[] invalidPortArgs = {"--password", "admin", "-p", "0"};
+		TestCommandLineInterface invalidPortTestCLI = new TestCommandLineInterface (new Options(), invalidPortArgs);
+		Assert.assertEquals ("CLI with invalid port, Concourse instance null", invalidPortTestCLI.getConcourse(), null);
+	}
+	
+	/**
+	 * Test {@link CommandLineInterface} for testing purposes, simply exists to take
+	 * command-line options and to attempt a Concourse connection.
+	 * @author hmitchell
+	 *
+	 */
+	private class TestCommandLineInterface extends CommandLineInterface{
+				
+		protected TestCommandLineInterface(Options options, String[] args) {
+			super(options, args);
+			setLoginAttemptsRemaining (0);
+			connectToConcourse();
+		}
+
+		@Override
+		protected void doTask() {
+			// does nothing.
+		}
+		
+	}
+
+	@Override
+	protected String getServerVersion() {
+        return "0.3.4";
+	}
+}


### PR DESCRIPTION
* modified build.gradle as suggested, but the resulting jar still did not contain these changes.  Either further modification of build.gradle, or building these changes to Maven, may be required before committing changes in client code which rely on changes in concourse-cli.

Summary of changes to cli framework:

CommandLineInterface now has a concourse and knows how to connectToConcourse and handleInvalidLogin attempts.  loginAttemptsRemaining is settable by the client, and isLoginFailed is visible to the client.

CommandLineInterfaceTest has an example implementation of CommandLineInterface to use for testInvalidPassword.